### PR TITLE
Use configure-aws-credentials Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
         description: 'Your AWS account ID you deployed GitHub Acitons IAM role via Terraform'
         required: true
         default: 'YOU_AWS_ACCOUNT_ID'
+      aws_iam_role:
+        description: 'Your AWS IAM role assumed by GitHub Actions using IAM identity provider'
+        required: true
+        default: 'GitHubActions'
 
 jobs:
   test-github-id-token-with-aws:
@@ -15,18 +19,12 @@ jobs:
       contents: read
     steps:
       - run: sleep 5 # there's still a race condition for now
-
+      # https://github.com/aws-actions/configure-aws-credentials
+      # Specifying role-to-assume without providing an aws-access-key-id or a web-identity-token-file will signal to the action that you wish to use the OIDC provider.
       - name: Configure AWS
-        run: |
-          export AWS_ROLE_ARN=arn:aws:iam::${{ github.event.inputs.aws_account_id}}:role/GitHubActions
-          export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-          export AWS_DEFAULT_REGION=ap-northeast-1
-
-          echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-          echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ github.event.inputs.aws_account_id}}:role/${{ github.event.inputs.aws_iam_role }}
+          aws-region: ap-northeast-1
       - run: aws sts get-caller-identity
       - run: aws s3 ls | grep github-actions


### PR DESCRIPTION
the Action supports ID token issued by GitHub OIDC and GitHub Acitons can assume the specified role using IAM identity provider.

See https://github.com/aws-actions/configure-aws-credentials/pull/262 for more details.